### PR TITLE
Update README to reflect latest OSSF SIG designations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Our mission is to Identify, Evaluate, Improve, Develop & Ease Deployment of univ
 
 Our vision is to improve the perception of security in open source software.
 
-# Governance
+## Governance
 
 The [CHARTER.md](CHARTER.md) outlines the scope and governance of our group activities.
 
@@ -38,45 +38,54 @@ This group is chaired by Josh Bressers (@joshbressers).
 
 The meeting invite is available on the public [OSSF calendar](https://calendar.google.com/calendar?cid=czYzdm9lZmhwNWk5cGZsdGI1cTY3bmdwZXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
 
+---
+
+## Special Interest Groups (SIGs) and Projects
+
+### SBOM Everywhere SIG
+
+* **Mission**: Improve Software Bill-of-Materials (SBOMs) tooling, training and adoption for the open software ecosystem.
+* **Meeting Times**: Monthly on the first Tuesday @10:30am Pacific Time starting January 15, 2023
+* **Where**: https://zoom.us/j/96699865335?pwd=QlFiNjU0OTdrOTE1KzBQcDV0Q1RHZz09 (overlaps WG call time)
+* **Meeting notes**: https://docs.google.com/document/d/1LS5PxWP4-dycCLCaZjf_DZtG-XJy2PUoq5jJQvDMQa8/edit
+* **Mailing list**: https://lists.openssf.org/g/openssf-sig-sbom
+
+### OSS Fuzzing SIG
+
+* **Mission**: Improve open source code fuzzing via open source tooling
+* **Meeting Times**: Every 2 weeks on Tuesday @8:00am Pacific Time
+* **Where**: https://zoom.us/j/99960722134?pwd=ZzZqdzY1eG9tMzQxWFI1Z0RhTkUxZz09
+* **Meeting notes**: https://docs.google.com/document/d/1u4_vL0UK69C7D3qatP9Q6gjGX1PMJjWnO4-3F4pJ0oo/edit#
+* **Mailing list**: https://groups.google.com/g/fuzzing-collaboration
+* **Related work** (non-OpenSSF):
+  * [OSS-Fuzz: Continuous fuzzing for open source software](https://github.com/google/oss-fuzz)
+  * [FuzzBench: Fuzzer Benchmarking As a Service](https://github.com/google/fuzzbench)
+  * [Fuzz-introspector](https://github.com/ossf/fuzz-introspector/) -  a tool to help fuzzer developers to get an understanding of their fuzzer’s performance and identify any potential blockers.
+
+---
+
+### Past SIGs
+
+#### Guide to Security Tools SIG
+
+* [Guide to Security Tools](https://github.com/ossf/wg-security-tooling/blob/main/guide.md)
+
+#### False Positive Suppression Specification SIG
+
+* [(DRAFT) False Positive Suppression Specification](https://docs.google.com/document/d/1811qanC8h9egv3Iszn_rrXGtAoSCz0YJGzp9vACjjH8/edit#)
+
+#### CVE Benchmark SIG
+
+* The [CVE benchmarking initiative](https://github.com/ossf-cve-benchmark/ossf-cve-benchmark) was announced at [BlackHat Europe 2020](https://www.blackhat.com/eu-20/briefings/schedule/#fps-are-cheap-show-me-the-cves-21345), presented by [Bas van Schaik](https://github.com/sj) and [Kevin Backhouse](https://github.com/kevinbackhouse).
+
+#### DAST scanning & web app definitions SIG
+
+* [Web Application Definition 1.0.0](https://github.com/ossf/wg-security-tooling/wiki/WebAppDefn)
+
+---
+
 ## Antitrust policy
 
 Linux Foundation meetings involve participation by industry competitors, and it is the intention of the Linux Foundation to conduct all of its activities in accordance with applicable antitrust and competition laws. It is therefore extremely important that attendees adhere to meeting agendas, and be aware of, and not participate in, any activities that are prohibited under applicable US state, federal or foreign antitrust and competition laws.
 
 Examples of types of actions that are prohibited at Linux Foundation meetings and in connection with Linux Foundation activities are described in the Linux Foundation Antitrust Policy available at <http://www.linuxfoundation.org/antitrust-policy>. If you have questions about these matters, please contact your company counsel, or if you are a member of the Linux Foundation, feel free to contact Andrew Updegrove of the firm of Gesmer Updegrove LLP, which provides legal counsel to the Linux Foundation.
-
-## Active projects
-
-### SBOM Everywhere SIG
-
-* [SBOM Everywhere Google Drive folder](https://drive.google.com/drive/folders/154MCLeIOQEgPpTUL7yzplOiipBVJ5KZJ)
-* [Mailing list](https://lists.openssf.org/g/openssf-sig-sbom)
-
-### (DRAFT) False Positive Suppression Specification 
-
-* [(DRAFT) False Positive Suppression Specification](https://docs.google.com/document/d/1811qanC8h9egv3Iszn_rrXGtAoSCz0YJGzp9vACjjH8/edit#) (Sandbox DRAFT)
-
-### Guide
-
-* [Guide to Security Tools](https://github.com/ossf/wg-security-tooling/blob/main/guide.md)
-
-### CVE benchmarking initiative
-* The [CVE benchmarking initiative](https://github.com/ossf-cve-benchmark/ossf-cve-benchmark) was announced at [BlackHat Europe 2020](https://www.blackhat.com/eu-20/briefings/schedule/#fps-are-cheap-show-me-the-cves-21345), presented by [Bas van Schaik](https://github.com/sj) and [Kevin Backhouse](https://github.com/kevinbackhouse).
-
-### OSS Fuzzing
-* Fuzzing Collaboration subgroup - focuses on improving fuzzing
-  - Meets montly starting 2022-01-04 at 10:30am Pacific Time (see the OpenSSF calendar) via [this Zoom link](https://zoom.us/j/99960722134?)
-  - [Meeting notes](https://docs.google.com/document/d/1u4_vL0UK69C7D3qatP9Q6gjGX1PMJjWnO4-3F4pJ0oo/edit#)
-  - Has its own [fuzzing-collaboration mailing list on Google Groups](https://groups.google.com/g/fuzzing-collaboration)
-* [Fuzz-introspector](https://github.com/ossf/fuzz-introspector/) -  a tool to help fuzzer developers to get an understanding of their fuzzer’s performance and identify any potential blockers.
-
-### DAST scanning and web application definition
-* Lead: Simon Bennetts
-* [Web Application Definition 1.0.0](https://github.com/ossf/wg-security-tooling/wiki/WebAppDefn)
-
-## Related non-OpenSSF work
-
-* [OSS-Fuzz: Continuous fuzzing for open source software](https://github.com/google/oss-fuzz)
-* [FuzzBench: Fuzzer Benchmarking As a Service](https://github.com/google/fuzzbench)
-
-### CodeQL rules
-* Coming


### PR DESCRIPTION
A reorg./cleanup, as promised in the WG call on 3/28 after presenting the OSSF latest "Architecture" diagram. This acks. the approved use of "SIG" and "project".